### PR TITLE
library: Add colors parameter to NavigationBarItem & FloatNavigationBarItem

### DIFF
--- a/docs/components/navigationbar.md
+++ b/docs/components/navigationbar.md
@@ -14,6 +14,7 @@ These components are typically used in conjunction with the `Scaffold` component
 
 ```kotlin
 import top.yukonga.miuix.kmp.basic.NavigationBar
+import top.yukonga.miuix.kmp.basic.NavigationBarDefaults
 import top.yukonga.miuix.kmp.basic.NavigationBarItem
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBar
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBarItem
@@ -72,6 +73,33 @@ Scaffold(
 )
 ```
 
+### Custom Colors
+
+Both item components accept `colors` from `NavigationBarDefaults.navigationBarItemColors()`. For example, use the theme's primary color for the selected item:
+
+```kotlin
+val itemColors = NavigationBarDefaults.navigationBarItemColors(
+    unselectedContentColor = MiuixTheme.colorScheme.onSurfaceContainer,
+    selectedContentColor = MiuixTheme.colorScheme.primary,
+)
+
+NavigationBar {
+    items.forEachIndexed { index, label ->
+        NavigationBarItem(
+            selected = selectedIndex == index,
+            onClick = { selectedIndex = index },
+            icon = icons[index],
+            label = label,
+            colors = itemColors,
+        )
+    }
+}
+```
+
+Pass the same `colors = itemColors` to `FloatingNavigationBarItem` inside a `FloatingNavigationBar` to customize its icons.
+
+Colors are base colors: their alpha is multiplied by `0.4` when unselected, `0.6` when unselected and pressed, and `0.5` when selected and pressed. Selected, unpressed content uses the supplied color unchanged. `Color.Transparent` stays transparent in every state.
+
 ## Component States
 
 ### Selected State
@@ -101,6 +129,7 @@ Scaffold(
 | label         | String        | Label of the item                | -             | Yes      |
 | modifier      | Modifier      | Modifier applied to the item     | Modifier      | No       |
 | enabled       | Boolean       | Whether the item is enabled      | true          | No       |
+| colors | NavigationBarItemColors | Icon and label base colors | NavigationBarDefaults.navigationBarItemColors() | No |
 | badge         | (@Composable () -> Unit)? | Optional badge shown on the item's icon, e.g. a `Badge` | null | No |
 
 ### FloatingNavigationBar Properties
@@ -127,6 +156,7 @@ Scaffold(
 | label         | String        | Label of the item                | -             | Yes      |
 | modifier      | Modifier      | Modifier applied to the item     | Modifier      | No       |
 | enabled       | Boolean       | Whether the item is enabled      | true          | No       |
+| colors | NavigationBarItemColors | Icon and label base colors | NavigationBarDefaults.navigationBarItemColors() | No |
 | badge         | (@Composable () -> Unit)? | Optional badge shown on the item's icon, e.g. a `Badge` | null | No |
 
 ### NavigationBarDefaults Object
@@ -145,6 +175,15 @@ The NavigationBarDefaults object provides default values for NavigationBar and N
 | SelectedPressedAlpha   | Float    | Alpha value for selected item when pressed   | 0.5f          |
 | UnselectedPressedAlpha | Float    | Alpha value for unselected item when pressed | 0.6f          |
 | UnselectedAlpha        | Float    | Alpha value for unselected item              | 0.4f          |
+
+#### navigationBarItemColors()
+
+A composable factory returning a remembered `NavigationBarItemColors`, shared by both navigation item components. Omitting `colors` preserves the default theme appearance.
+
+| Parameter | Type | Description | Default Value |
+| --------- | ---- | ----------- | ------------- |
+| unselectedContentColor | Color | Base color for unselected content | MiuixTheme.colorScheme.onSurfaceContainer |
+| selectedContentColor | Color | Base color for selected content | MiuixTheme.colorScheme.onSurfaceContainer |
 
 ### FloatingNavigationBarDefaults Object
 

--- a/docs/zh_CN/components/navigationbar.md
+++ b/docs/zh_CN/components/navigationbar.md
@@ -14,6 +14,7 @@
 
 ```kotlin
 import top.yukonga.miuix.kmp.basic.NavigationBar
+import top.yukonga.miuix.kmp.basic.NavigationBarDefaults
 import top.yukonga.miuix.kmp.basic.NavigationBarItem
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBar
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBarItem
@@ -72,6 +73,33 @@ Scaffold(
 )
 ```
 
+### 自定义颜色
+
+两种导航项都支持通过 `NavigationBarDefaults.navigationBarItemColors()` 创建的 `colors`。例如，使用主题主色显示选中项：
+
+```kotlin
+val itemColors = NavigationBarDefaults.navigationBarItemColors(
+    unselectedContentColor = MiuixTheme.colorScheme.onSurfaceContainer,
+    selectedContentColor = MiuixTheme.colorScheme.primary,
+)
+
+NavigationBar {
+    items.forEachIndexed { index, label ->
+        NavigationBarItem(
+            selected = selectedIndex == index,
+            onClick = { selectedIndex = index },
+            icon = icons[index],
+            label = label,
+            colors = itemColors,
+        )
+    }
+}
+```
+
+在 `FloatingNavigationBar` 内向 `FloatingNavigationBarItem` 传入同样的 `colors = itemColors`，即可自定义其图标颜色。
+
+传入的颜色是基础颜色：未选中时 alpha 乘以 `0.4`，未选中且按下时乘以 `0.6`，选中且按下时乘以 `0.5`。选中且未按下时直接使用传入的颜色。`Color.Transparent` 在所有状态下均保持透明。
+
 ## 组件状态
 
 ### 选中状态
@@ -101,6 +129,7 @@ Scaffold(
 | label    | String      | 文本标签         | -      | 是       |
 | modifier | Modifier    | 应用于导航项的修饰符 | Modifier | 否       |
 | enabled  | Boolean     | 是否启用         | true     | 否       |
+| colors | NavigationBarItemColors | 图标和文本的基础颜色 | NavigationBarDefaults.navigationBarItemColors() | 否 |
 | badge    | (@Composable () -> Unit)? | 显示在该项图标上的可选徽章，通常是一个 `Badge` | null | 否 |
 
 ### FloatingNavigationBar 属性
@@ -127,6 +156,7 @@ Scaffold(
 | label    | String      | 文本标签         | -      | 是       |
 | modifier | Modifier    | 应用于导航项的修饰符 | Modifier | 否       |
 | enabled  | Boolean     | 是否启用         | true     | 否       |
+| colors | NavigationBarItemColors | 图标和文本的基础颜色 | NavigationBarDefaults.navigationBarItemColors() | 否 |
 | badge    | (@Composable () -> Unit)? | 显示在该项图标上的可选徽章，通常是一个 `Badge` | null | 否 |
 
 ### NavigationBarDefaults 对象
@@ -145,6 +175,15 @@ NavigationBarDefaults 对象提供了 NavigationBar 和 NavigationBarItem 组件
 | SelectedPressedAlpha   | Float    | 选中项按压时的透明度       | 0.5f   |
 | UnselectedPressedAlpha | Float    | 未选中项按压时的透明度     | 0.6f   |
 | UnselectedAlpha        | Float    | 未选中项的透明度           | 0.4f   |
+
+#### navigationBarItemColors()
+
+此可组合工厂函数返回通过 `remember` 缓存的 `NavigationBarItemColors`，供两种导航项共用。不传入 `colors` 时保持默认主题效果。
+
+| 参数 | 类型 | 说明 | 默认值 |
+| ---- | ---- | ---- | ------ |
+| unselectedContentColor | Color | 未选中内容的基础颜色 | MiuixTheme.colorScheme.onSurfaceContainer |
+| selectedContentColor | Color | 选中内容的基础颜色 | MiuixTheme.colorScheme.onSurfaceContainer |
 
 ### FloatingNavigationBarDefaults 对象
 

--- a/miuix-ui/build.gradle.kts
+++ b/miuix-ui/build.gradle.kts
@@ -52,6 +52,10 @@ kotlin {
     applyMiuixSourceSetHierarchy()
 
     sourceSets {
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+
         commonMain.dependencies {
             api(projects.miuixCore)
             api(projects.miuixSquircle)

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -146,6 +147,7 @@ fun RowScope.NavigationBarItem(
     icon: ImageVector,
     label: String,
     modifier: Modifier = Modifier,
+    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     enabled: Boolean = true,
     badge: (@Composable () -> Unit)? = null,
 ) {
@@ -153,18 +155,7 @@ fun RowScope.NavigationBarItem(
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    val onSurfaceContainerColor = MiuixTheme.colorScheme.onSurfaceContainer
-    val tint = when {
-        isPressed -> if (selected) {
-            onSurfaceContainerColor.copy(alpha = NavigationBarDefaults.SelectedPressedAlpha)
-        } else {
-            onSurfaceContainerColor.copy(alpha = NavigationBarDefaults.UnselectedPressedAlpha)
-        }
-
-        selected -> onSurfaceContainerColor
-
-        else -> onSurfaceContainerColor.copy(NavigationBarDefaults.UnselectedAlpha)
-    }
+    val tint = colors.contentColor(selected, isPressed)
     val fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
     val mode = LocalNavigationBarDisplayMode.current
 
@@ -387,24 +378,14 @@ fun FloatingNavigationBarItem(
     icon: ImageVector,
     label: String,
     modifier: Modifier = Modifier,
+    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     enabled: Boolean = true,
     badge: (@Composable () -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    val onSurfaceContainerColor = MiuixTheme.colorScheme.onSurfaceContainer
-    val tint = when {
-        isPressed -> if (selected) {
-            onSurfaceContainerColor.copy(alpha = FloatingNavigationBarDefaults.SelectedPressedAlpha)
-        } else {
-            onSurfaceContainerColor.copy(alpha = FloatingNavigationBarDefaults.UnselectedPressedAlpha)
-        }
-
-        selected -> onSurfaceContainerColor
-
-        else -> onSurfaceContainerColor.copy(FloatingNavigationBarDefaults.UnselectedAlpha)
-    }
+    val tint = colors.contentColor(selected, isPressed)
 
     Column(
         modifier = modifier
@@ -478,6 +459,39 @@ object NavigationBarDefaults {
 
     /** The alpha value for an unselected item. */
     val UnselectedAlpha = 0.4f
+
+    /**
+     * The default colors for the [NavigationBarItem].
+     */
+    @Composable
+    fun navigationBarItemColors(
+        unselectedContentColor: Color = MiuixTheme.colorScheme.onSurfaceContainer,
+        selectedContentColor: Color = MiuixTheme.colorScheme.onSurfaceContainer,
+    ): NavigationBarItemColors = remember(unselectedContentColor, selectedContentColor) {
+        NavigationBarItemColors(
+            unselectedContentColor = unselectedContentColor,
+            selectedContentColor = selectedContentColor,
+        )
+    }
+}
+
+@Immutable
+data class NavigationBarItemColors(
+    private val unselectedContentColor: Color,
+    private val selectedContentColor: Color,
+) {
+    @Stable
+    internal fun contentColor(selected: Boolean, isPressed: Boolean): Color = when {
+        isPressed -> if (selected) {
+            selectedContentColor.copy(alpha = NavigationBarDefaults.SelectedPressedAlpha)
+        } else {
+            unselectedContentColor.copy(alpha = NavigationBarDefaults.UnselectedPressedAlpha)
+        }
+
+        selected -> selectedContentColor
+
+        else -> unselectedContentColor.copy(NavigationBarDefaults.UnselectedAlpha)
+    }
 }
 
 /** Contains default values used by [FloatingNavigationBar] and [FloatingNavigationBarItem]. */

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
@@ -147,8 +147,8 @@ fun RowScope.NavigationBarItem(
     icon: ImageVector,
     label: String,
     modifier: Modifier = Modifier,
-    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     enabled: Boolean = true,
+    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     badge: (@Composable () -> Unit)? = null,
 ) {
     val itemHeight = NavigationBarDefaults.ItemHeight
@@ -378,8 +378,8 @@ fun FloatingNavigationBarItem(
     icon: ImageVector,
     label: String,
     modifier: Modifier = Modifier,
-    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     enabled: Boolean = true,
+    colors: NavigationBarItemColors = NavigationBarDefaults.navigationBarItemColors(),
     badge: (@Composable () -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/NavigationBar.kt
@@ -138,6 +138,7 @@ fun NavigationBar(
  * @param label The label of the item.
  * @param modifier The modifier to be applied to the [NavigationBarItem].
  * @param enabled Whether the item is enabled.
+ * @param colors The icon and label colors, with state opacity applied to their alpha.
  * @param badge The optional badge shown on the item's icon, typically a [Badge].
  */
 @Composable
@@ -369,6 +370,7 @@ fun FloatingNavigationBar(
  * @param label The label of the item.
  * @param modifier The modifier to be applied to the [FloatingNavigationBarItem].
  * @param enabled Whether the item is enabled.
+ * @param colors The icon and label colors, with state opacity applied to their alpha.
  * @param badge The optional badge shown on the item's icon, typically a [Badge].
  */
 @Composable
@@ -461,7 +463,11 @@ object NavigationBarDefaults {
     val UnselectedAlpha = 0.4f
 
     /**
-     * The default colors for the [NavigationBarItem].
+     * The default colors for [NavigationBarItem] and [FloatingNavigationBarItem].
+     * State opacity multiplies each color's alpha, preserving transparent colors.
+     *
+     * @param unselectedContentColor The base color for unselected content.
+     * @param selectedContentColor The base color for selected content.
      */
     @Composable
     fun navigationBarItemColors(
@@ -475,6 +481,12 @@ object NavigationBarDefaults {
     }
 }
 
+/**
+ * Base content colors shared by [NavigationBarItem] and [FloatingNavigationBarItem].
+ *
+ * @param unselectedContentColor The unselected icon and label color before state opacity.
+ * @param selectedContentColor The selected icon and label color before state opacity.
+ */
 @Immutable
 data class NavigationBarItemColors(
     private val unselectedContentColor: Color,
@@ -483,14 +495,14 @@ data class NavigationBarItemColors(
     @Stable
     internal fun contentColor(selected: Boolean, isPressed: Boolean): Color = when {
         isPressed -> if (selected) {
-            selectedContentColor.copy(alpha = NavigationBarDefaults.SelectedPressedAlpha)
+            selectedContentColor.copy(alpha = selectedContentColor.alpha * NavigationBarDefaults.SelectedPressedAlpha)
         } else {
-            unselectedContentColor.copy(alpha = NavigationBarDefaults.UnselectedPressedAlpha)
+            unselectedContentColor.copy(alpha = unselectedContentColor.alpha * NavigationBarDefaults.UnselectedPressedAlpha)
         }
 
         selected -> selectedContentColor
 
-        else -> unselectedContentColor.copy(NavigationBarDefaults.UnselectedAlpha)
+        else -> unselectedContentColor.copy(alpha = unselectedContentColor.alpha * NavigationBarDefaults.UnselectedAlpha)
     }
 }
 

--- a/miuix-ui/src/commonTest/kotlin/top/yukonga/miuix/kmp/basic/NavigationBarItemColorsTest.kt
+++ b/miuix-ui/src/commonTest/kotlin/top/yukonga/miuix/kmp/basic/NavigationBarItemColorsTest.kt
@@ -1,0 +1,53 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.basic
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NavigationBarItemColorsTest {
+    @Test
+    fun transparentContentStaysTransparentInEveryState() {
+        val colors = NavigationBarItemColors(Color.Transparent, Color.Transparent)
+
+        for (selected in listOf(false, true)) {
+            for (pressed in listOf(false, true)) {
+                assertEquals(Color.Transparent, colors.contentColor(selected, pressed))
+            }
+        }
+    }
+
+    @Test
+    fun translucentContentRetainsItsAlphaAndHue() {
+        val unselected = Color(0x804080C0)
+        val selected = Color(0x4080C040)
+        val colors = NavigationBarItemColors(unselected, selected)
+
+        assertEquals(selected, colors.contentColor(selected = true, isPressed = false))
+        assertEquals(
+            selected.copy(alpha = selected.alpha * 0.5f),
+            colors.contentColor(selected = true, isPressed = true),
+        )
+        assertEquals(
+            unselected.copy(alpha = unselected.alpha * 0.4f),
+            colors.contentColor(selected = false, isPressed = false),
+        )
+        assertEquals(
+            unselected.copy(alpha = unselected.alpha * 0.6f),
+            colors.contentColor(selected = false, isPressed = true),
+        )
+    }
+
+    @Test
+    fun opaqueContentPreservesOriginalStateOpacity() {
+        val color = Color(0xFF4080C0)
+        val colors = NavigationBarItemColors(color, color)
+
+        assertEquals(color, colors.contentColor(selected = true, isPressed = false))
+        assertEquals(color.copy(alpha = 0.5f), colors.contentColor(selected = true, isPressed = true))
+        assertEquals(color.copy(alpha = 0.4f), colors.contentColor(selected = false, isPressed = false))
+        assertEquals(color.copy(alpha = 0.6f), colors.contentColor(selected = false, isPressed = true))
+    }
+}


### PR DESCRIPTION
## 🎯 Goal

Add support for providing custom `colors` to `NavigationBarItem` and `FloatNavigationBarItem`.

This allows callers to customize the colors of icons and labels displayed inside the `NavigationBar`, providing more flexibility for different UI themes and use cases.

## 🛠 Implementation Details

- Added a `colors` parameter to `NavigationBarItem`.
- Added a `colors` parameter to `FloatNavigationBarItem`.
- Use the provided colors to control the appearance of icons and labels.
- Preserve the existing default color behavior when custom colors are not provided.
- Added visual examples to demonstrate the supported color customization.

## 🖼️ Visual Examples

### NavigationBarItem

<img width="532" height="952" alt="image" src="https://github.com/user-attachments/assets/1492a81d-0fd2-4960-90d8-c06d23fba6e4" />


### FloatNavigationBarItem

<img width="532" height="952" alt="image" src="https://github.com/user-attachments/assets/bda11b66-476b-46ba-b2f5-3e1d59cd56c4" />

## ✨ Example

```kotlin
NavigationBarItem(
    selected = selected,
    onClick = { /* ... */ },
    icon = MiuixIcons.Home,
    label = "Home",
    colors = NavigationBarItemDefaults.navigationBarItemColors(
        unselectedContentColor = MiuixTheme.colorScheme.onSurfaceContainer,
        selectedContentColor = MiuixTheme.colorScheme.primary,
    )
)
```

The same customization is available for `FloatNavigationBarItem`.

## ✅ Result

Consumers can now customize the icon and label colors of navigation bar items without having to implement their own navigation item components.