### PR TITLE
library: add LocalNavTransitionScope to miuix-nav

### DIFF
--- a/docs/guide/miuix-nav.md
+++ b/docs/guide/miuix-nav.md
@@ -134,7 +134,11 @@ val myTransition = navGraphicsTransition { scope ->
 }
 ```
 
-`NavTransitionScope` exposes `relativeDepth`, `role`, `change`, `gesture`, `layoutSize`, `layoutDirection` and `density`.
+`NavTransitionScope` exposes `relativeDepth`, `role`, `change`, `gesture`, `isRunning`, `layoutSize`, `layoutDirection` and `density`.
+
+Read `LocalNavTransitionScope.current` from entry content when it needs Miuix's live navigation
+state. Use `isRunning` for the coarse transition lifecycle, and read `relativeDepth`, `gesture` or
+`settle` in a deferred `graphicsLayer` block when implementing entry-local effects.
 
 Generic looks (fade, scale, shared-axis, …) are deliberately not shipped as presets — each is a few lines on this builder. A cross-fade, for instance:
 

--- a/docs/zh_CN/guide/miuix-nav.md
+++ b/docs/zh_CN/guide/miuix-nav.md
@@ -134,7 +134,11 @@ val myTransition = navGraphicsTransition { scope ->
 }
 ```
 
-`NavTransitionScope` 暴露 `relativeDepth`、`role`、`change`、`gesture`、`layoutSize`、`layoutDirection`、`density`。
+`NavTransitionScope` 暴露 `relativeDepth`、`role`、`change`、`gesture`、`isRunning`、`layoutSize`、`layoutDirection`、`density`。
+
+entry 内容需要 Miuix 的实时导航状态时，可读取 `LocalNavTransitionScope.current`。
+使用 `isRunning` 判断转场生命周期；实现 entry 局部效果时，`relativeDepth`、`gesture` 或
+`settle` 应在 `graphicsLayer` 等延迟读取区中使用。
 
 通用样式（淡入淡出、缩放、共享轴等）刻意不作为预设内置——在这个 builder 上每种只需几行。例如交叉淡入淡出：
 

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/LiveNavTransitionScope.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/LiveNavTransitionScope.kt
@@ -44,6 +44,11 @@ internal class LiveNavTransitionScope(
 
     override val gesture: NavGesture? get() = presentation.gesture
 
+    // gestureActive deliberately uses a derived Boolean: gesture is replaced on every pointer
+    // event, but consumers reading this from composition only need the start/end boundaries.
+    override val isRunning: Boolean
+        get() = presentation.gestureActive || presentation.settle != null || presentation.animatedTop.isRunning
+
     override val settle: NavSettle? get() = presentation.settle
 
     /** Coarse gesture flag for composition-time branch dispatch (see navDirectionalTransition). */

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/LocalNavTransitionScope.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/LocalNavTransitionScope.kt
@@ -1,0 +1,25 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.core
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import top.yukonga.miuix.kmp.nav.transition.NavTransitionScope
+
+/**
+ * The live Miuix transition scope for the current entry.
+ *
+ * Use this local when entry content needs Miuix-specific navigation data such as relative depth,
+ * gesture progress, settle state or the coarse [NavTransitionScope.isRunning] lifecycle signal.
+ * Reads of per-frame values remain deferred when performed from a `graphicsLayer` block.
+ *
+ * Accessing this local outside a [NavDisplay] entry is an error.
+ */
+public val LocalNavTransitionScope: ProvidableCompositionLocal<NavTransitionScope> =
+    compositionLocalOf {
+        error(
+            "Unexpected access to LocalNavTransitionScope. Access it only inside a " +
+                "NavDisplay entry.",
+        )
+    }

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
@@ -857,18 +857,17 @@ private fun NavEntryHost(
     // the top (d <= 0), the upper neighbour's transition while covered (0 < d). The per-frame
     // visual is then a pure deferred read inside the transition's own graphicsLayer.
     val activeTransition = if ((depthBuckets and DEPTH_BUCKET_GOVERNS_OWN) != 0) ownTransition else upperTransition
+    val transitionScope = LiveNavTransitionScope(
+        presentation = presentation,
+        entryIndex = entryIndex,
+        isRemoving = entry.presentation.isRemoving,
+        change = change,
+        layoutSize = layoutSize,
+        layoutDirection = layoutDirection,
+        density = density,
+    )
     val entryModifier = with(activeTransition) {
-        Modifier.transformEntry(
-            LiveNavTransitionScope(
-                presentation = presentation,
-                entryIndex = entryIndex,
-                isRemoving = entry.presentation.isRemoving,
-                change = change,
-                layoutSize = layoutSize,
-                layoutDirection = layoutDirection,
-                density = density,
-            ),
-        )
+        Modifier.transformEntry(transitionScope)
     }
 
     val clipModifier = if ((depthBuckets and DEPTH_BUCKET_CLIP_CORNERS) != 0) {
@@ -922,7 +921,11 @@ private fun NavEntryHost(
             ProvideNavEntryViewModelStore(vmOwner) {
                 ProvideNavEntryLifecycle(lifecycleOwner) {
                     stateHolder.EntryStateContent(entry.contentKey) {
-                        movableContent { entry.Content() }
+                        movableContent {
+                            CompositionLocalProvider(LocalNavTransitionScope provides transitionScope) {
+                                entry.Content()
+                            }
+                        }
                     }
                 }
             }

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/transition/NavTransitionScope.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/transition/NavTransitionScope.kt
@@ -114,9 +114,11 @@ interface NavTransitionScope {
     /**
      * Whether this [NavDisplay] is currently handling a navigation transition.
      *
-     * This is a coarse, composition-safe signal: it changes at transition boundaries rather than
-     * for every frame of the driving depth. It remains `true` for both an interactive gesture and
-     * the settle that follows its release, and becomes `false` once the navigation motion is idle.
+     * Unlike per-frame values such as [relativeDepth], this is a coarse, composition-safe signal.
+     * It changes at transition boundaries rather than for every frame of the driving depth.
+     *
+     * It remains `true` for both an interactive gesture and the settle that follows its release,
+     * and becomes `false` once the navigation motion is idle.
      */
     val isRunning: Boolean get() = gesture != null || settle != null
 

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/transition/NavTransitionScope.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/transition/NavTransitionScope.kt
@@ -112,6 +112,15 @@ interface NavTransitionScope {
     val gesture: NavGesture?
 
     /**
+     * Whether this [NavDisplay] is currently handling a navigation transition.
+     *
+     * This is a coarse, composition-safe signal: it changes at transition boundaries rather than
+     * for every frame of the driving depth. It remains `true` for both an interactive gesture and
+     * the settle that follows its release, and becomes `false` once the navigation motion is idle.
+     */
+    val isRunning: Boolean get() = gesture != null || settle != null
+
+    /**
      * Self-driven settle context, or `null` while a finger drives the float or the stack is at
      * rest. Default `null` so existing implementations stay source-compatible (the property set
      * is append-only).

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavTransitionScopeTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavTransitionScopeTest.kt
@@ -1,0 +1,51 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.core
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private data object TransitionScopeRoute : NavKey
+
+private data object TransitionScopeRouteB : NavKey
+
+@OptIn(ExperimentalTestApi::class)
+class NavTransitionScopeTest {
+
+    @Test
+    fun reportsRunningUntilNavigationSettles() = runComposeUiTest {
+        var sawRunning = false
+        var runningAtEnd = false
+        val backStack = navBackStackOf(TransitionScopeRoute)
+
+        setContent {
+            NavDisplay(backStack = backStack, effects = NavDisplayEffects.None) {
+                entry<TransitionScopeRoute> {
+                    val running = LocalNavTransitionScope.current.isRunning
+                    sawRunning = sawRunning || running
+                    runningAtEnd = running
+                    Box(Modifier.fillMaxSize())
+                }
+                entry<TransitionScopeRouteB> {
+                    val running = LocalNavTransitionScope.current.isRunning
+                    sawRunning = sawRunning || running
+                    runningAtEnd = running
+                    Box(Modifier.fillMaxSize())
+                }
+            }
+        }
+
+        waitForIdle()
+        backStack.add(TransitionScopeRouteB)
+        waitForIdle()
+        assertFalse(runningAtEnd)
+        assertTrue(sawRunning)
+    }
+}


### PR DESCRIPTION
Expose live navigation transition state, including isRunning, to entry content.